### PR TITLE
Add GMRs into the stub but also make improvements and provide way of generating import notification updates response

### DIFF
--- a/BtmsBackendStub.sln.DotSettings
+++ b/BtmsBackendStub.sln.DotSettings
@@ -1,0 +1,5 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=btms/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ched/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=cheda/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=gmrs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/README.md
+++ b/README.md
@@ -1,50 +1,77 @@
-# btms-backend-stub
+# Defra BTMS Backend Stub
 
-Core delivery C# ASP.NET backend template.
+This service provides stubbed responses for specific BTMS requests.
 
-* [Install MongoDB](#install-mongodb)
-* [Inspect MongoDB](#inspect-mongodb)
-* [Testing](#testing)
-* [Running](#running)
-* [Dependabot](#dependabot)
+## Prerequisites
 
-### Install MongoDB
-- Install [MongoDB](https://www.mongodb.com/docs/manual/tutorial/#installation) on your local machine
-- Start MongoDB:
-```bash
-sudo mongod --dbpath ~/mongodb-cdp
+The solution requires:
+
+- .NET 9
+
+  ```bash
+  brew tap isen-ng/dotnet-sdk-versions
+  brew install --cask dotnet-sdk9
+  ```
+
+- Docker
+
+## Installation
+
+1. Clone this repository
+2. Install the required tools with `dotnet tool restore`
+3. Check the solution builds with `dotnet build`
+4. Check the service builds with `docker build .`
+
+## Running
+
+1. Run the application via Docker:
+   ```
+   docker build -t btms-backend-stub .
+   docker run -p 8085:8085 btms-backend-stub
+   ```
+2. Navigate to http://localhost:8085
+
+## Responses
+
+See the Scenarios folder for all available responses. Examples are as follows:
+
+Get import notification updates:
+```http request
+http://localhost:8085/api/import-notifications
 ```
 
-### Inspect MongoDB
-
-To inspect the Database and Collections locally:
-```bash
-mongosh
+Get individual import notification:
+```http request
+http://localhost:8085/api/import-notifications/CHEDA.GB.2024.4792831
 ```
 
-### Testing
-
-Run the tests with:
-
-Tests run by running a full `WebApplication` backed by [Ephemeral MongoDB](https://github.com/asimmon/ephemeral-mongo).
-Tests do not use mocking of any sort and read and write from the in-memory database.
-
-```bash
-dotnet test
-````
-
-### Running
-
-Run CDP-Deployments application:
-```bash
-dotnet run --project BtmsBackendStub --launch-profile Development
+Get individual movement:
+```http request
+http://localhost:8085/api/movements/24GBCUDNXBN1JNRAR5
 ```
 
-### SonarCloud
+Get individual goods movement:
+```http request
+http://localhost:8085/api/gmrs/GMRA00KBHFE0
+```
 
-Example SonarCloud configuration are available in the GitHub Action workflows.
+## Development
 
-### Dependabot
+Any new scenarios should be added to the Scenarios folder and they will be included automatically.
 
-We have added an example dependabot configuration file to the repository. You can enable it by renaming
-the [.github/example.dependabot.yml](.github/example.dependabot.yml) to `.github/dependabot.yml`
+Scenarios requiring specific configuration in code should be registered in the `WireMockHostedService`.
+
+## Testing
+
+Run the service via Docker and test the output is as expected.
+
+# Linting
+
+We use [CSharpier](https://csharpier.com) to lint our code.
+
+You can run the linter with `dotnet csharpier .`
+
+## License
+
+This project is licensed under The Open Government Licence (OGL) Version 3.  
+See the [LICENSE](./LICENSE) for more details.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The solution requires:
 
 See the Scenarios folder for all available responses. Examples are as follows:
 
-Get import notification updates:
+Get import notification updates (see [Utility Endpoints](#utility-endpoints)):
 ```http request
 http://localhost:8085/api/import-notifications
 ```
@@ -54,6 +54,15 @@ Get individual goods movement:
 ```http request
 http://localhost:8085/api/gmrs/GMRA00KBHFE0
 ```
+
+## Utility Endpoints
+
+A utility endpoint has been provided that will generate the import notification updates content based on the import notifications available in the Scenarios folder. Please use this if you want to update the stub response for import notification updates.
+```http request
+http://localhost:8085/utility/import-notification-updates
+```
+
+Copy the output and save it over [btms-import-notification-updates.json](src/BtmsBackendStub/Scenarios/btms-import-notification-updates.json).
 
 ## Development
 

--- a/src/BtmsBackendStub/BtmsBackendStub.csproj
+++ b/src/BtmsBackendStub/BtmsBackendStub.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WireMock.Net" Version="1.6.11" />
+    <PackageReference Include="WireMock.Net" Version="1.7.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BtmsBackendStub/Endpoints.cs
+++ b/src/BtmsBackendStub/Endpoints.cs
@@ -12,4 +12,9 @@ public static class Endpoints
     {
         public static string Get(string? mrn = null) => $"/api/movements{(mrn is null ? string.Empty : $"/{mrn}")}";
     }
+
+    public static class Gmrs
+    {
+        public static string Get(string? gmrId = null) => $"/api/gmrs{(gmrId is null ? string.Empty : $"/{gmrId}")}";
+    }
 }

--- a/src/BtmsBackendStub/Program.cs
+++ b/src/BtmsBackendStub/Program.cs
@@ -1,5 +1,4 @@
 using Defra.BtmsBackendStub.Configuration;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -16,10 +15,10 @@ public static class Program
     private static IHostBuilder CreateHostBuilder(string[] args)
     {
         return Host.CreateDefaultBuilder(args)
-            .ConfigureServices((host, services) => ConfigureServices(services, host.Configuration));
+            .ConfigureServices((_, services) => ConfigureServices(services));
     }
 
-    private static void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    private static void ConfigureServices(IServiceCollection services)
     {
         services.AddLogging(logging => logging.AddConsole().AddDebug());
         

--- a/src/BtmsBackendStub/Scenarios/btms-import-notification-updates.json
+++ b/src/BtmsBackendStub/Scenarios/btms-import-notification-updates.json
@@ -8,7 +8,7 @@
       "type": "import-notifications",
       "id": "CHEDA.GB.2024.4792831",
       "attributes": {
-        "updatedEntity": "2024-12-11T08:12:58.792Z",
+        "updatedEntity": "2025-02-26T09:31:47.7762581Z",
         "referenceNumber": "CHEDA.GB.2024.4792831"
       },
       "links": {
@@ -17,42 +17,9 @@
     },
     {
       "type": "import-notifications",
-      "id": "CHEDD.GB.2024.5019877",
-      "attributes": {
-        "updatedEntity": "2024-12-11T08:12:59.114Z",
-        "referenceNumber": "CHEDD.GB.2024.5019877"
-      },
-      "links": {
-        "self": "/api/import-notifications/CHEDD.GB.2024.5019877"
-      }
-    },
-    {
-      "type": "import-notifications",
-      "id": "CHEDP.GB.2024.4144842",
-      "attributes": {
-        "updatedEntity": "2024-12-11T08:12:59.741Z",
-        "referenceNumber": "CHEDP.GB.2024.4144842"
-      },
-      "links": {
-        "self": "/api/import-notifications/CHEDP.GB.2024.4144842"
-      }
-    },
-    {
-      "type": "import-notifications",
-      "id": "CHEDPP.GB.2024.3726460",
-      "attributes": {
-        "updatedEntity": "2024-12-11T08:12:59.947Z",
-        "referenceNumber": "CHEDPP.GB.2024.3726460"
-      },
-      "links": {
-        "self": "/api/import-notifications/CHEDPP.GB.2024.3726460"
-      }
-    },
-    {
-      "type": "import-notifications",
       "id": "CHEDA.GB.2024.5129502",
       "attributes": {
-        "updatedEntity": "2024-12-11T08:13:00.108Z",
+        "updatedEntity": "2025-02-26T09:31:47.7766152Z",
         "referenceNumber": "CHEDA.GB.2024.5129502"
       },
       "links": {
@@ -61,61 +28,193 @@
     },
     {
       "type": "import-notifications",
-      "id": "CHEDA.GB.2024.011113000003",
+      "id": "CHEDD.GB.2024.5019877",
       "attributes": {
-        "updatedEntity": "2024-12-11T08:13:00.203Z",
-        "referenceNumber": "CHEDA.GB.2024.011113000003"
+        "updatedEntity": "2025-02-26T09:31:47.7766163Z",
+        "referenceNumber": "CHEDD.GB.2024.5019877"
       },
       "links": {
-        "self": "/api/import-notifications/CHEDA.GB.2024.011113000003"
+        "self": "/api/import-notifications/CHEDD.GB.2024.5019877"
       }
     },
     {
       "type": "import-notifications",
-      "id": "CHEDA.GB.2024.011114000001",
+      "id": "CHEDD.GB.2024.5118377",
       "attributes": {
-        "updatedEntity": "2024-12-11T08:13:01.234Z",
-        "referenceNumber": "CHEDA.GB.2024.011114000001"
+        "updatedEntity": "2025-02-26T09:31:47.7766166Z",
+        "referenceNumber": "CHEDD.GB.2024.5118377"
       },
       "links": {
-        "self": "/api/import-notifications/CHEDA.GB.2024.011114000001"
+        "self": "/api/import-notifications/CHEDD.GB.2024.5118377"
       }
     },
     {
       "type": "import-notifications",
-      "id": "CHEDA.GB.2024.011114000002",
+      "id": "CHEDD.GB.2024.5226413",
       "attributes": {
-        "updatedEntity": "2024-12-11T08:13:01.546Z",
-        "referenceNumber": "CHEDA.GB.2024.011114000002"
+        "updatedEntity": "2025-02-26T09:31:47.7766168Z",
+        "referenceNumber": "CHEDD.GB.2024.5226413"
       },
       "links": {
-        "self": "/api/import-notifications/CHEDA.GB.2024.011114000002"
+        "self": "/api/import-notifications/CHEDD.GB.2024.5226413"
       }
     },
     {
       "type": "import-notifications",
-      "id": "CHEDA.GB.2024.011114000003",
+      "id": "CHEDD.GB.2024.5351769",
       "attributes": {
-        "updatedEntity": "2024-12-11T08:13:01.831Z",
-        "referenceNumber": "CHEDA.GB.2024.011114000003"
+        "updatedEntity": "2025-02-26T09:31:47.7766171Z",
+        "referenceNumber": "CHEDD.GB.2024.5351769"
       },
       "links": {
-        "self": "/api/import-notifications/CHEDA.GB.2024.011114000003"
+        "self": "/api/import-notifications/CHEDD.GB.2024.5351769"
       }
     },
     {
       "type": "import-notifications",
-      "id": "CHEDA.GB.2024.011115000001",
+      "id": "CHEDP.GB.2024.4144842",
       "attributes": {
-        "updatedEntity": "2024-12-11T08:13:02.953Z",
-        "referenceNumber": "CHEDA.GB.2024.011115000001"
+        "updatedEntity": "2025-02-26T09:31:47.7766173Z",
+        "referenceNumber": "CHEDP.GB.2024.4144842"
       },
       "links": {
-        "self": "/api/import-notifications/CHEDA.GB.2024.011115000001"
+        "self": "/api/import-notifications/CHEDP.GB.2024.4144842"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDP.GB.2024.5093007",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766175Z",
+        "referenceNumber": "CHEDP.GB.2024.5093007"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDP.GB.2024.5093007"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDP.GB.2024.5101765",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766181Z",
+        "referenceNumber": "CHEDP.GB.2024.5101765"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDP.GB.2024.5101765"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDP.GB.2024.5125476",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766351Z",
+        "referenceNumber": "CHEDP.GB.2024.5125476"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDP.GB.2024.5125476"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDP.GB.2024.5132323",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766355Z",
+        "referenceNumber": "CHEDP.GB.2024.5132323"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDP.GB.2024.5132323"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDP.GB.2024.5137241",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766358Z",
+        "referenceNumber": "CHEDP.GB.2024.5137241"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDP.GB.2024.5137241"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDP.GB.2024.5140733",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766360Z",
+        "referenceNumber": "CHEDP.GB.2024.5140733"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDP.GB.2024.5140733"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDP.GB.2024.5192091",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766362Z",
+        "referenceNumber": "CHEDP.GB.2024.5192091"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDP.GB.2024.5192091"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDP.GB.2024.5249145",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766364Z",
+        "referenceNumber": "CHEDP.GB.2024.5249145"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDP.GB.2024.5249145"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDP.GB.2024.5253621",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766366Z",
+        "referenceNumber": "CHEDP.GB.2024.5253621"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDP.GB.2024.5253621"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDP.GB.2024.5270338",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766370Z",
+        "referenceNumber": "CHEDP.GB.2024.5270338"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDP.GB.2024.5270338"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDP.GB.2024.5328437",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766373Z",
+        "referenceNumber": "CHEDP.GB.2024.5328437"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDP.GB.2024.5328437"
+      }
+    },
+    {
+      "type": "import-notifications",
+      "id": "CHEDPP.GB.2024.3726460",
+      "attributes": {
+        "updatedEntity": "2025-02-26T09:31:47.7766375Z",
+        "referenceNumber": "CHEDPP.GB.2024.3726460"
+      },
+      "links": {
+        "self": "/api/import-notifications/CHEDPP.GB.2024.3726460"
       }
     }
   ],
   "meta": {
-    "total": 7494
+    "total": 19
   }
 }

--- a/src/BtmsBackendStub/WireMockExtensions.cs
+++ b/src/BtmsBackendStub/WireMockExtensions.cs
@@ -139,6 +139,30 @@ public static class WireMockExtensions
             wireMock.StubSingleImportNotification(chedReferenceNumber: chedReferenceNumber);
     }
 
+    public static void StubUtilityEndpoints(this WireMockServer wireMock)
+    {
+        var data = GetAllStubChedReferenceNumbers().Select(x => new
+        {
+            type = "import-notifications",
+            id = x,
+            attributes = new { updatedEntity = DateTime.UtcNow.ToString("O"), referenceNumber = x },
+            links = new { self = $"/api/import-notifications/{x}" }
+        }).ToList();
+
+        wireMock.Given(Request.Create()
+                .WithPath("/utility/import-notification-updates")
+                .UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(StatusCodes.Status200OK)
+                .WithBodyAsJson(
+                    new
+                    {
+                        links = new { self = "/api/import-notifications", first = "/api/import-notifications" },
+                        data,
+                        meta = new { total = data.Count }
+                    }, indented: true));
+    }
+
     private static IEnumerable<string> GetAllStubChedReferenceNumbers() =>
         Anchor
             .Assembly.GetManifestResourceNames()

--- a/src/BtmsBackendStub/WireMockHostedService.cs
+++ b/src/BtmsBackendStub/WireMockHostedService.cs
@@ -34,10 +34,18 @@ public class WireMockHostedService(IOptions<BtmsStubOptions> options, ILogger<Wi
 
     private void ConfigureStubbedData()
     {
+        if (_wireMockServer is null) return;
+        
         // NB. import notifications returned by the following do not exist in the stub and will 404
-        _wireMockServer?.StubImportNotificationUpdates();
-        _wireMockServer?.StubSingleMovements();
-        _wireMockServer!.StubSingleImportNotifications();
+        _wireMockServer.StubImportNotificationUpdates();
+        _wireMockServer.StubAllMovements();
+        _wireMockServer.StubAllGmrs();
+        _wireMockServer.StubAllImportNotifications();
+        
+        // Example failures
+        _wireMockServer.StubSingleMovement(shouldFail: true, mrn: "24GBCUDNXBN1JNRTP1");
+        _wireMockServer.StubSingleGmr(shouldFail: true, gmrId: "GMRA00KBHTP1");
+        _wireMockServer.StubSingleImportNotification(shouldFail: true, chedReferenceNumber: "CHEDA.GB.2024.4792TP1");
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/src/BtmsBackendStub/WireMockHostedService.cs
+++ b/src/BtmsBackendStub/WireMockHostedService.cs
@@ -36,16 +36,16 @@ public class WireMockHostedService(IOptions<BtmsStubOptions> options, ILogger<Wi
     {
         if (_wireMockServer is null) return;
         
-        // NB. import notifications returned by the following do not exist in the stub and will 404
         _wireMockServer.StubImportNotificationUpdates();
         _wireMockServer.StubAllMovements();
         _wireMockServer.StubAllGmrs();
         _wireMockServer.StubAllImportNotifications();
         
-        // Example failures
         _wireMockServer.StubSingleMovement(shouldFail: true, mrn: "24GBCUDNXBN1JNRTP1");
         _wireMockServer.StubSingleGmr(shouldFail: true, gmrId: "GMRA00KBHTP1");
         _wireMockServer.StubSingleImportNotification(shouldFail: true, chedReferenceNumber: "CHEDA.GB.2024.4792TP1");
+        
+        _wireMockServer.StubUtilityEndpoints();
     }
 
     public Task StopAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
GMRs were missing, they are now added.

Any new CHEDs, movements or GMRs can be added to the scenarios folder and they will be included automatically.

`/utility/import-notifications-updates` is a new endpoint that will produce the updates response, which can then be used to replace the `btms-import-notification-updates.json` content in the repo.

README has been updated with details of how to build and run and what responses exist.